### PR TITLE
fix: remove parantheses to make `@derive` with `except` work

### DIFF
--- a/lib/toon/encoder.ex
+++ b/lib/toon/encoder.ex
@@ -87,7 +87,7 @@ defimpl Toon.Encoder, for: Any do
         only
 
       except = Keyword.get(opts, :except) ->
-        Map.keys(struct) -- ([:__struct__] -- except)
+        Map.keys(struct) -- [:__struct__ | except]
 
       true ->
         Map.keys(struct) -- [:__struct__]

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Toon.MixProject do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "test/fixtures"]
   defp elixirc_paths(_), do: ["lib"]
 
   def application do

--- a/test/fixtures/test_structs.ex
+++ b/test/fixtures/test_structs.ex
@@ -1,0 +1,4 @@
+defmodule Toon.Fixtures.UserWithExcept do
+  @derive {Toon.Encoder, except: [:password]}
+  defstruct [:name, :email, :password]
+end

--- a/test/toon/encoder_test.exs
+++ b/test/toon/encoder_test.exs
@@ -1,0 +1,20 @@
+defmodule Toon.EncoderTest do
+  use ExUnit.Case, async: true
+
+  alias Toon.Fixtures.UserWithExcept
+
+  describe "fields_to_encode/2 with except option" do
+    @user_attrs %{name: "Alice", email: "a@b.com", password: "secret"}
+
+    test "excludes specified fields from encoding" do
+      user = struct(UserWithExcept, @user_attrs)
+
+      encoded = user |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+      {:ok, decoded} = Toon.decode(encoded)
+
+      assert Map.has_key?(decoded, "name") == true
+      assert Map.has_key?(decoded, "email") == true
+      assert Map.has_key?(decoded, "password") == false
+    end
+  end
+end


### PR DESCRIPTION
The expression `[:__struct__] -- except` evaluates to `[:__struct__]` (since except typically doesn't contain `:__struct__)`, so the final result is `Map.keys(struct) -- [:__struct__]` — the except fields are never removed.

This especially happens when deriving from Ecto schemas and ignoring the `__meta__` like this:
`@derive {Toon.Encoder, except: [:__meta__]}`

This solves it by removing the parentheses. The PR adds necessary tests to make sure this is fixed.