### PR TITLE
fix: normalize dispatch to encoder for included types

### DIFF
--- a/lib/toon/encoder.ex
+++ b/lib/toon/encoder.ex
@@ -87,7 +87,7 @@ defimpl Toon.Encoder, for: Any do
         only
 
       except = Keyword.get(opts, :except) ->
-        Map.keys(struct) -- ([:__struct__] -- except)
+        Map.keys(struct) -- [:__struct__ | except]
 
       true ->
         Map.keys(struct) -- [:__struct__]

--- a/lib/toon/encoder.ex
+++ b/lib/toon/encoder.ex
@@ -32,7 +32,7 @@ defprotocol Toon.Encoder do
 
   Returns IO data that can be converted to a string.
   """
-  @spec encode(t, keyword()) :: iodata()
+  @spec encode(t, keyword()) :: iodata() | map()
   def encode(value, opts)
 end
 
@@ -42,13 +42,10 @@ defimpl Toon.Encoder, for: Any do
 
     quote do
       defimpl Toon.Encoder, for: unquote(module) do
-        def encode(struct, opts) do
-          map =
-            struct
-            |> Map.take(unquote(fields))
-            |> Map.new(fn {k, v} -> {to_string(k), v} end)
-
-          Toon.Encode.encode!(map, opts)
+        def encode(struct, _opts) do
+          struct
+          |> Map.take(unquote(fields))
+          |> Map.new(fn {k, v} -> {to_string(k), Toon.Utils.normalize(v)} end)
         end
       end
     end

--- a/lib/toon/shared/utils.ex
+++ b/lib/toon/shared/utils.ex
@@ -194,6 +194,13 @@ defmodule Toon.Utils do
     Enum.map(value, &normalize/1)
   end
 
+  # # Structs - dispatch to Toon.Encoder protocol
+  def normalize(%{__struct__: _} = struct) do
+    struct
+    |> Toon.Encoder.encode([])
+    |> IO.iodata_to_binary()
+  end
+
   def normalize(value) when is_map(value) do
     Map.new(value, fn {k, v} ->
       {to_string(k), normalize(v)}

--- a/lib/toon/shared/utils.ex
+++ b/lib/toon/shared/utils.ex
@@ -194,11 +194,17 @@ defmodule Toon.Utils do
     Enum.map(value, &normalize/1)
   end
 
-  # # Structs - dispatch to Toon.Encoder protocol
+  # Structs - dispatch to Toon.Encoder protocol
   def normalize(%{__struct__: _} = struct) do
-    struct
-    |> Toon.Encoder.encode([])
-    |> IO.iodata_to_binary()
+    result = Toon.Encoder.encode(struct, [])
+
+    # If encoder returns iodata (string), convert it to binary
+    # If encoder returns a map (from @derive), use it directly
+    case result do
+      binary when is_binary(binary) -> binary
+      map when is_map(map) -> map
+      iodata -> IO.iodata_to_binary(iodata)
+    end
   end
 
   def normalize(value) when is_map(value) do

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Toon.MixProject do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "test/fixtures"]
   defp elixirc_paths(_), do: ["lib"]
 
   def application do

--- a/test/fixtures/test_structs.ex
+++ b/test/fixtures/test_structs.ex
@@ -1,0 +1,4 @@
+defmodule Toon.Fixtures.UserWithExcept do
+  @derive {Toon.Encoder, except: [:password]}
+  defstruct [:name, :email, :password]
+end

--- a/test/fixtures/test_structs.ex
+++ b/test/fixtures/test_structs.ex
@@ -2,3 +2,14 @@ defmodule Toon.Fixtures.UserWithExcept do
   @derive {Toon.Encoder, except: [:password]}
   defstruct [:name, :email, :password]
 end
+
+defmodule Toon.Fixtures.CustomDate do
+  @moduledoc "Test struct with explicit Toon.Encoder implementation"
+  defstruct [:year, :month, :day]
+end
+
+defimpl Toon.Encoder, for: Toon.Fixtures.CustomDate do
+  def encode(%{year: y, month: m, day: d}, _opts) do
+    "#{y}-#{String.pad_leading(to_string(m), 2, "0")}-#{String.pad_leading(to_string(d), 2, "0")}"
+  end
+end

--- a/test/fixtures/test_structs.ex
+++ b/test/fixtures/test_structs.ex
@@ -1,4 +1,5 @@
 defmodule Toon.Fixtures.UserWithExcept do
+  @moduledoc false
   @derive {Toon.Encoder, except: [:password]}
   defstruct [:name, :email, :password]
 end
@@ -12,4 +13,16 @@ defimpl Toon.Encoder, for: Toon.Fixtures.CustomDate do
   def encode(%{year: y, month: m, day: d}, _opts) do
     "#{y}-#{String.pad_leading(to_string(m), 2, "0")}-#{String.pad_leading(to_string(d), 2, "0")}"
   end
+end
+
+defmodule Toon.Fixtures.Person do
+  @moduledoc false
+  @derive Toon.Encoder
+  defstruct [:name, :age]
+end
+
+defmodule Toon.Fixtures.Company do
+  @moduledoc false
+  @derive Toon.Encoder
+  defstruct [:name, :ceo]
 end

--- a/test/nested_struct_test.exs
+++ b/test/nested_struct_test.exs
@@ -1,0 +1,60 @@
+defmodule Toon.NestedStructTest do
+  use ExUnit.Case, async: true
+
+  alias Toon.Fixtures.{Company, Person}
+
+  describe "nested struct encoding" do
+    test "encodes and decodes nested structs correctly" do
+      person = %Person{name: "John", age: 30}
+      company = %Company{name: "Acme", ceo: person}
+
+      # Encode the nested struct
+      encoded = Toon.encode!(company)
+
+      # Should produce TOON format
+      assert is_binary(encoded)
+
+      # Decode and verify
+      {:ok, decoded} = Toon.decode(encoded)
+
+      # Verify structure
+      assert decoded["name"] == "Acme"
+      assert decoded["ceo"]["name"] == "John"
+      assert decoded["ceo"]["age"] == 30
+    end
+
+    test "normalizes nested structs to maps" do
+      person = %Person{name: "Jane", age: 25}
+      company = %Company{name: "TechCo", ceo: person}
+
+      # normalize should convert nested structs to maps
+      normalized = Toon.Utils.normalize(company)
+
+      assert is_map(normalized)
+      assert normalized["name"] == "TechCo"
+      assert is_map(normalized["ceo"])
+      assert normalized["ceo"]["name"] == "Jane"
+      assert normalized["ceo"]["age"] == 25
+    end
+
+    test "handles deeply nested structs" do
+      person1 = %Person{name: "Alice", age: 35}
+      company1 = %Company{name: "StartupA", ceo: person1}
+
+      person2 = %Person{name: "Bob", age: 40}
+      company2 = %Company{name: "StartupB", ceo: person2}
+
+      # Create a list of companies (testing nested structs in lists)
+      data = %{"companies" => [company1, company2]}
+
+      encoded = Toon.encode!(data)
+      {:ok, decoded} = Toon.decode(encoded)
+
+      assert length(decoded["companies"]) == 2
+      assert decoded["companies"] |> Enum.at(0) |> Map.get("name") == "StartupA"
+      assert decoded["companies"] |> Enum.at(0) |> Map.get("ceo") |> Map.get("name") == "Alice"
+      assert decoded["companies"] |> Enum.at(1) |> Map.get("name") == "StartupB"
+      assert decoded["companies"] |> Enum.at(1) |> Map.get("ceo") |> Map.get("name") == "Bob"
+    end
+  end
+end

--- a/test/toon/encoder_test.exs
+++ b/test/toon/encoder_test.exs
@@ -9,12 +9,18 @@ defmodule Toon.EncoderTest do
     test "excludes specified fields from encoding" do
       user = struct(UserWithExcept, @user_attrs)
 
-      encoded = user |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
-      {:ok, decoded} = Toon.decode(encoded)
+      # Derived encoder now returns a normalized map
+      encoded_map = Toon.Encoder.encode(user, [])
 
-      assert Map.has_key?(decoded, "name") == true
-      assert Map.has_key?(decoded, "email") == true
-      assert Map.has_key?(decoded, "password") == false
+      assert Map.has_key?(encoded_map, "name") == true
+      assert Map.has_key?(encoded_map, "email") == true
+      assert Map.has_key?(encoded_map, "password") == false
+
+      # Can still be encoded to TOON format
+      toon_string = Toon.encode!(encoded_map)
+      {:ok, decoded} = Toon.decode(toon_string)
+
+      assert decoded == encoded_map
     end
   end
 
@@ -22,21 +28,23 @@ defmodule Toon.EncoderTest do
     test "dispatches to explicit Toon.Encoder implementation" do
       date = %CustomDate{year: 2024, month: 1, day: 15}
 
-      # Direct encoder call
+      # Explicit encoder still returns iodata/string
       encoded_directly = date |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+      assert encoded_directly == "2024-01-15"
 
-      # normalize/1 should produce identical output
+      # normalize/1 should produce identical output for explicit encoders
       assert Toon.Utils.normalize(date) == encoded_directly
     end
 
     test "dispatches to @derive Toon.Encoder" do
       user = %UserWithExcept{name: "Bob", email: "bob@test.com", password: "secret"}
 
-      # Direct encoder call
-      encoded_directly = user |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+      # Derived encoder returns normalized map
+      encoded_map = Toon.Encoder.encode(user, [])
 
       # normalize/1 should produce identical output
-      assert Toon.Utils.normalize(user) == encoded_directly
+      assert Toon.Utils.normalize(user) == encoded_map
+      assert encoded_map == %{"name" => "Bob", "email" => "bob@test.com"}
     end
   end
 end

--- a/test/toon/encoder_test.exs
+++ b/test/toon/encoder_test.exs
@@ -1,7 +1,7 @@
 defmodule Toon.EncoderTest do
   use ExUnit.Case, async: true
 
-  alias Toon.Fixtures.UserWithExcept
+  alias Toon.Fixtures.{CustomDate, UserWithExcept}
 
   describe "fields_to_encode/2 with except option" do
     @user_attrs %{name: "Alice", email: "a@b.com", password: "secret"}
@@ -15,6 +15,28 @@ defmodule Toon.EncoderTest do
       assert Map.has_key?(decoded, "name") == true
       assert Map.has_key?(decoded, "email") == true
       assert Map.has_key?(decoded, "password") == false
+    end
+  end
+
+  describe "Toon.Utils.normalize/1 dispatches to Toon.Encoder for structs" do
+    test "dispatches to explicit Toon.Encoder implementation" do
+      date = %CustomDate{year: 2024, month: 1, day: 15}
+
+      # Direct encoder call
+      encoded_directly = date |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+
+      # normalize/1 should produce identical output
+      assert Toon.Utils.normalize(date) == encoded_directly
+    end
+
+    test "dispatches to @derive Toon.Encoder" do
+      user = %UserWithExcept{name: "Bob", email: "bob@test.com", password: "secret"}
+
+      # Direct encoder call
+      encoded_directly = user |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+
+      # normalize/1 should produce identical output
+      assert Toon.Utils.normalize(user) == encoded_directly
     end
   end
 end

--- a/test/toon/encoder_test.exs
+++ b/test/toon/encoder_test.exs
@@ -1,0 +1,20 @@
+defmodule Toon.EncoderTest do
+  use ExUnit.Case, async: true
+
+  alias Toon.Fixtures.UserWithExcept
+
+  describe "fields_to_encode/2 with except option" do
+    @user_attrs %{name: "Alice", email: "a@b.com", password: "secret"}
+
+    test "excludes specified fields from encoding" do
+      user = struct(UserWithExcept, @user_attrs)
+
+      encoded = user |> Toon.Encoder.encode([]) |> IO.iodata_to_binary()
+      {:ok, decoded} = Toon.decode(encoded)
+
+      assert Map.has_key?(decoded, "name") == true
+      assert Map.has_key?(decoded, "email") == true
+      assert Map.has_key?(decoded, "password") == false
+    end
+  end
+end


### PR DESCRIPTION
Whenever a `struct` or schema do have an included type (like DateTime), the `Toon.encode!/2` does not dispatch included types to `encode!` as well. This way, you always must write the implementation for the protocol by hand whenever you `struct` is more complex.

This fix adds a dispatch to `encode!/2` whenever a `struct` includes custom data types that already have an implementation for `Toon.Encoder`. In other cases, the error just goes through, following "Let it crash" philosophy of Elixir.

⚠️ Caution: I have created this fix on top of #3, so merging #3 makes sense before merging this.

Closes issue #2